### PR TITLE
웹소켓 구성 추가 및 로그인 페이지 버튼 추가

### DIFF
--- a/abaloneDjango/consumers.py
+++ b/abaloneDjango/consumers.py
@@ -8,12 +8,12 @@ class abalone_consumer(WebsocketConsumer):
 
     # websocket이 연결 되었을 때
     def connect(self):
-        self.room_name = 'abalone'
-        self.room_group_name = 'game_%s' % self.room_name
+        self.game_name = 'abalone'
+        self.game_group_name = 'game_%s' % self.game_name
 
         # 그룹에 Join 하는 메서드이다.
         async_to_sync(self.channel_layer.group_add)(
-            self.room_group_name,
+            self.game_group_name,
             self.channel_name
         )
 
@@ -23,7 +23,7 @@ class abalone_consumer(WebsocketConsumer):
     def disconnect(self, close_code):
         # 그룹을 leave 하는 메서드이다.
         async_to_sync(self.channel_layer.group_discard)(
-            self.room_group_name,
+            self.game_group_name,
             self.channel_name
         )
 
@@ -33,15 +33,15 @@ class abalone_consumer(WebsocketConsumer):
         message = text_data_json['message']
         # 그룹으로 메세지를 돌려보내주는 부분이다.
         async_to_sync(self.channel_layer.group_send)(
-            self.room_group_name,
+            self.game_group_name,
             {
-                'type': 'chat_message',
+                'type': 'game_message',
                 'message': message
             }
         )
 
     # 위의 receive 메서드에서 그룹으로 메세지를 보내면 그 메세지를 받아 처리하는 부분이다.
-    def chat_message(self, event):
+    def game_message(self, event):
         message = event['message']
 
         # 클라이언트로 웹소켓을 통해 받은 메세지를 다시 보내주는 부분이다.

--- a/abaloneDjango/consumers.py
+++ b/abaloneDjango/consumers.py
@@ -1,0 +1,50 @@
+from asgiref.sync import async_to_sync
+from channels.generic.websocket import WebsocketConsumer
+import json
+
+
+#웹소켓 class instance를 만듦
+class abalone_consumer(WebsocketConsumer):
+
+    # websocket이 연결 되었을 때
+    def connect(self):
+        self.room_name = 'abalone'
+        self.room_group_name = 'game_%s' % self.room_name
+
+        # 그룹에 Join 하는 메서드이다.
+        async_to_sync(self.channel_layer.group_add)(
+            self.room_group_name,
+            self.channel_name
+        )
+
+        self.accept()
+
+    # 연결이 끊어졌을 때
+    def disconnect(self, close_code):
+        # 그룹을 leave 하는 메서드이다.
+        async_to_sync(self.channel_layer.group_discard)(
+            self.room_group_name,
+            self.channel_name
+        )
+
+    # 웹소켓으로부터 메세지를 받아 처리하는 부분이다.
+    def receive(self, text_data):
+        text_data_json = json.loads(text_data)
+        message = text_data_json['message']
+        # 그룹으로 메세지를 돌려보내주는 부분이다.
+        async_to_sync(self.channel_layer.group_send)(
+            self.room_group_name,
+            {
+                'type': 'chat_message',
+                'message': message
+            }
+        )
+
+    # 위의 receive 메서드에서 그룹으로 메세지를 보내면 그 메세지를 받아 처리하는 부분이다.
+    def chat_message(self, event):
+        message = event['message']
+
+        # 클라이언트로 웹소켓을 통해 받은 메세지를 다시 보내주는 부분이다.
+        self.send(text_data=json.dumps({
+            'message': message
+        }))

--- a/abaloneDjango/router.py
+++ b/abaloneDjango/router.py
@@ -1,0 +1,8 @@
+from django.urls import re_path
+
+from . import consumers
+
+
+websocket_urlpatterns = [
+    re_path('abalone/<str:username>/', consumers.abalone_consumer),
+]

--- a/abaloneDjango/routing.py
+++ b/abaloneDjango/routing.py
@@ -1,0 +1,15 @@
+from channels.auth import AuthMiddlewareStack
+from channels.routing import ProtocolTypeRouter, URLRouter
+
+from . import router
+
+
+application = ProtocolTypeRouter({
+    # (http->django views is added by default)
+    'websocket': AuthMiddlewareStack(
+        URLRouter(
+            router.websocket_urlpatterns
+        )
+    ),
+})
+

--- a/abaloneDjango/settings.py
+++ b/abaloneDjango/settings.py
@@ -41,6 +41,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'abaloneDjango',  # 추가
+    'channels', # Websocket 추가
 
     'rest_framework.authtoken',
 ]
@@ -74,6 +75,8 @@ TEMPLATES = [
 ]
 
 WSGI_APPLICATION = 'abaloneDjango.wsgi.application'
+
+ASGI_APPLICATION = 'abaloneDjango.routing.application' # Websocket 추가
 
 
 # Database
@@ -125,7 +128,6 @@ USE_TZ = True
 STATIC_URL = '/static/'
 
 
-
 # ... 처음이시면 위치에 신경 쓸 필요 없고
 # ... settings.py에 있기만 해도 됩니다.
 REST_FRAMEWORK = {
@@ -136,4 +138,16 @@ REST_FRAMEWORK = {
         'rest_framework.permissions.IsAuthenticated',
     ]
 }
+
+
+# ASGI 통신을 위한 Redis Layers 설정
+CHANNEL_LAYERS = {
+    'default': {
+        'BACKEND': 'channels_redis.core.RedisChannelLayer',
+        'CONFIG': {
+            'hosts': [('localhost', 6379)],
+        },
+    },
+}
+
 # ...

--- a/abaloneDjango/templates/abaloneDjango/honor.html
+++ b/abaloneDjango/templates/abaloneDjango/honor.html
@@ -18,7 +18,24 @@
     </style>
 
     <script type="text/javascript">
+    // 클라이언트와 서버의 웹소켓 통신을 가능하도록 연결시켜주는 부분이다.
+    // router.py에서의 url과 일치하도록 해 주어야한다.
+    var web_socket = new WebSocket('ws://' + window.location.host + '/abalone/<str:username>/');
 
+    // onmessage는 counsumers에서 보내는 메세지를 받는 부분이다.
+    web_socket.onmessage = function(e) {
+        var data = JSON.parse(e.data);
+        var message = data['message'];
+
+        if (message == 'assin') {
+            // 0.5초 후 작동해야할 코드(원정시작 대기)
+            setTimeout(function(){
+               document.location.href = "{% url 'mycard_view' username=username %}";
+            }, 500);
+        } else if (message == 'init') {
+            document.location.href = "{% url 'knight_select_view' username=username %}";
+        }
+    };
     </script>
 
 

--- a/abaloneDjango/templates/abaloneDjango/honor.html
+++ b/abaloneDjango/templates/abaloneDjango/honor.html
@@ -28,10 +28,13 @@
         var message = data['message'];
 
         if (message == 'assin') {
-            // 0.5초 후 작동해야할 코드(원정시작 대기)
-            setTimeout(function(){
-               document.location.href = "{% url 'mycard_view' username=username %}";
-            }, 500);
+            document.location.href = "{% url 'mycard_view' username=username %}";
+        } else if (message == 'game_succ') {
+            document.location.href = "{% url 'knight_select_view' username=username %}";
+        } else if (message == 'game_fail') {
+            document.location.href = "{% url 'knight_select_view' username=username %}";
+        } else if (message == 'game_complete') {
+            document.location.href = "{% url 'knight_select_view' username=username %}";
         } else if (message == 'init') {
             document.location.href = "{% url 'knight_select_view' username=username %}";
         }

--- a/abaloneDjango/templates/abaloneDjango/knight_election.html
+++ b/abaloneDjango/templates/abaloneDjango/knight_election.html
@@ -18,11 +18,34 @@
 
     <script type="text/javascript">
 
+    // 클라이언트와 서버의 웹소켓 통신을 가능하도록 연결시켜주는 부분이다.
+    // router.py에서의 url과 일치하도록 해 주어야한다.
+    var web_socket = new WebSocket('ws://' + window.location.host + '/abalone/<str:username>/');
+
     function submitFrom(succyn){
         document.forms[0].expeditionseq.value={{expeditionseq}};
         document.forms[0].succyn.value = succyn;
         document.forms[0].submit();
+
+        web_socket.send(JSON.stringify({
+            'message': 'election'
+        }));
     }
+
+    // onmessage는 counsumers에서 보내는 메세지를 받는 부분이다.
+    web_socket.onmessage = function(e) {
+        var data = JSON.parse(e.data);
+        var message = data['message'];
+
+        if (message == 'assin') {
+            // 0.5초 후 작동해야할 코드
+            setTimeout(function(){
+               document.location.href = "{% url 'mycard_view' username=username %}";
+            }, 500);
+        } else if (message == 'init') {
+            document.location.href = "{% url 'knight_select_view' username=username %}";
+        }
+    };
     </script>
 
 
@@ -47,7 +70,7 @@
             <td width="200">참가자</td>
         </tr>
         <tr>
-            {% for  expedition2 in expeditionlist.all %}
+            {% for  expedition2 in expeditionlist %}
                 <tr>
                     <td>{{ expedition2.expeditionSeq }} </td>
                     <td>{{ expedition2.succUserCnt }}/{{ expedition2.expeditionUserCnt }}</td>

--- a/abaloneDjango/templates/abaloneDjango/knight_election.html
+++ b/abaloneDjango/templates/abaloneDjango/knight_election.html
@@ -38,12 +38,17 @@
         var message = data['message'];
 
         if (message == 'assin') {
-            // 0.5초 후 작동해야할 코드
-            setTimeout(function(){
-               document.location.href = "{% url 'mycard_view' username=username %}";
-            }, 500);
+            document.location.href = "{% url 'mycard_view' username=username %}";
+        } else if (message == 'game_succ') {
+            document.location.href = "{% url 'knight_select_view' username=username %}";
+        } else if (message == 'game_fail') {
+            document.location.href = "{% url 'knight_select_view' username=username %}";
+        } else if (message == 'game_complete') {
+            document.location.href = "{% url 'knight_select_view' username=username %}";
         } else if (message == 'init') {
             document.location.href = "{% url 'knight_select_view' username=username %}";
+        } else if (message == 'expeditionSeq_ini') {
+            document.location.href = "{% url 'knight_expedition_view' username=username %}";
         }
     };
     </script>

--- a/abaloneDjango/templates/abaloneDjango/knight_expedition.html
+++ b/abaloneDjango/templates/abaloneDjango/knight_expedition.html
@@ -34,18 +34,20 @@
         var data = JSON.parse(e.data);
         var message = data['message'];
 
-        if (message == 'assin') {
-            // 0.5초 후 작동해야할 코드
-            setTimeout(function(){
-               document.location.href = "{% url 'mycard_view' username=username %}";
-            }, 500);
+        if (message == 'election') {
+            document.location.href = "{% url 'knight_expedition_view' username=username %}";
+        } else if (message == 'assin') {
+            document.location.href = "{% url 'mycard_view' username=username %}";
+        } else if (message == 'game_succ') {
+            document.location.href = "{% url 'knight_select_view' username=username %}";
+        } else if (message == 'game_fail') {
+            document.location.href = "{% url 'knight_select_view' username=username %}";
+        } else if (message == 'game_complete') {
+            document.location.href = "{% url 'knight_select_view' username=username %}";
         } else if (message == 'init') {
             document.location.href = "{% url 'knight_select_view' username=username %}";
-        } else if (message == 'election') {
-            // 0.5초 후 작동해야할 코드
-            setTimeout(function(){
-               document.location.href = "{% url 'knight_expedition_view' username=username %}";
-            }, 500);
+        } else if (message == 'expeditionSeq_ini') {
+            document.location.href = "{% url 'knight_expedition_view' username=username %}";
         }
     };
     </script>

--- a/abaloneDjango/templates/abaloneDjango/knight_expedition.html
+++ b/abaloneDjango/templates/abaloneDjango/knight_expedition.html
@@ -15,23 +15,40 @@
             background-size:100%;
             width:100%;
         }
-
         .td_expedition{
             padding : 10px 0px;
         }
     </style>
 
     <script type="text/javascript">
-    var timer = setInterval("timer_procedure();",10000);
-
-    function timer_procedure(){
-        document.location.href = "{% url 'knight_expedition_view' username=username %}";
-    }
     function submitFrom(){
         document.forms[0].submit();
     }
-    </script>
 
+    // 클라이언트와 서버의 웹소켓 통신을 가능하도록 연결시켜주는 부분이다.
+    // router.py에서의 url과 일치하도록 해 주어야한다.
+    var web_socket = new WebSocket('ws://' + window.location.host + '/abalone/<str:username>/');
+
+    // onmessage는 counsumers에서 보내는 메세지를 받는 부분이다.
+    web_socket.onmessage = function(e) {
+        var data = JSON.parse(e.data);
+        var message = data['message'];
+
+        if (message == 'assin') {
+            // 0.5초 후 작동해야할 코드
+            setTimeout(function(){
+               document.location.href = "{% url 'mycard_view' username=username %}";
+            }, 500);
+        } else if (message == 'init') {
+            document.location.href = "{% url 'knight_select_view' username=username %}";
+        } else if (message == 'election') {
+            // 0.5초 후 작동해야할 코드
+            setTimeout(function(){
+               document.location.href = "{% url 'knight_expedition_view' username=username %}";
+            }, 500);
+        }
+    };
+    </script>
 
 </head>
 <body>
@@ -47,25 +64,24 @@
     <br>
     <br>
     <div class="expedition1">
-    <table  height="120">
-    <tbody>
-        <tr>
-            {% for  expedition in expeditionlist %}
-                <td scope="row"  width="20%" class="td_expedition">
-                    <img src="{% static expedition.succYn %}_expedition.JPG" width="100%">
-                </td>
+        <table  height="120">
+        <tbody>
+            <tr>
+                {% for  expedition in expeditionlist %}
+                    <td scope="row"  width="20%" class="td_expedition">
+                        <img src="{% static expedition.succYn %}_expedition.JPG" width="100%">
+                    </td>
+                {% endfor %}
+                {% if expeditionseq < 6 %}
+                    <td scope="row" width="100%" style="vertical-align:top;">
+                        <img src="{% static 'S' %}_expedition.JPG" width="75" onclick="submitFrom();">
+                    </td>
+                {% endif %}
 
-            {% endfor %}
-            {% if expeditionseq < 6 %}
-                <td scope="row" width="100%">
-                    <img src="{% static 'S' %}_expedition.JPG" width="75" onclick="submitFrom();">
-                </td>
-            {% endif %}
-
-        </tr>
-       </tbody>
-     </table>
-</div>
+            </tr>
+           </tbody>
+         </table>
+    </div>
     <table class="table"  height="80">
         <tr>
             <td width="10">차</td>
@@ -82,7 +98,6 @@
                     <td>{{ expedition2.usernamelist }}</td>
                 </tr>
             {% endfor %}
-
         </tr>
     </table>
 

--- a/abaloneDjango/templates/abaloneDjango/knight_login.html
+++ b/abaloneDjango/templates/abaloneDjango/knight_login.html
@@ -1,4 +1,3 @@
-{# knight_login.html #}
 {% extends 'abaloneDjango/base.html' %}
 
 {% block body %}
@@ -9,4 +8,21 @@
     </table>
     <input type="submit" value="Submit" width="100%"/>
 </form>
+
+<a href="{% url 'knight_auto_view' username='기수' %}"><input value="김기수" type="button" width="100%"/></a>
+<a href="{% url 'knight_auto_view' username='홍종' %}"><input value="김홍종" type="button" width="100%"/></a>
+<a href="{% url 'knight_auto_view' username='승훈' %}"><input value="도승훈" type="button" width="100%"/></a>
+<a href="{% url 'knight_auto_view' username='현이' %}"><input value="문현이" type="button" width="100%"/></a>
+<a href="{% url 'knight_auto_view' username='원대' %}"><input value="서원대" type="button" width="100%"/></a>
+<br>
+<a href="{% url 'knight_auto_view' username='용수' %}"><input value="안용수" type="button" width="100%"/></a>
+<a href="{% url 'knight_auto_view' username='현철' %}"><input value="오현철" type="button" width="100%"/></a>
+<a href="{% url 'knight_auto_view' username='경진' %}"><input value="이경진" type="button" width="100%"/></a>
+<a href="{% url 'knight_auto_view' username='상림' %}"><input value="이상림" type="button" width="100%"/></a>
+<a href="{% url 'knight_auto_view' username='승규' %}"><input value="이승규" type="button" width="100%"/></a>
+<br>
+<a href="{% url 'knight_auto_view' username='윤정' %}"><input value="주윤정" type="button" width="100%"/></a>
+<a href="{% url 'knight_auto_view' username='원영' %}"><input value="최원영" type="button" width="100%"/></a>
+<a href="{% url 'knight_auto_view' username='윤경' %}"><input value="허윤경" type="button" width="100%"/></a>
+<a href="{% url 'knight_auto_view' username='인의' %}"><input value="홍인의" type="button" width="100%"/></a>
 {% endblock body %}

--- a/abaloneDjango/templates/abaloneDjango/knight_select.html
+++ b/abaloneDjango/templates/abaloneDjango/knight_select.html
@@ -50,8 +50,26 @@
         id_knightliststr.value = knightliststr;
         document.forms[0].submit();
     }
-    </script>
 
+    // 클라이언트와 서버의 웹소켓 통신을 가능하도록 연결시켜주는 부분이다.
+    // router.py에서의 url과 일치하도록 해 주어야한다.
+    var web_socket = new WebSocket('ws://' + window.location.host + '/abalone/<str:username>/');
+
+    // onmessage는 counsumers에서 보내는 메세지를 받는 부분이다.
+    web_socket.onmessage = function(e) {
+        var data = JSON.parse(e.data);
+        var message = data['message'];
+
+        if (message == 'assin') {
+            // 0.5초 후 작동해야할 코드(원정시작 대기)
+            setTimeout(function(){
+               document.location.href = "{% url 'mycard_view' username=username %}";
+            }, 500);
+        } else if (message == 'init') {
+            document.location.href = "{% url 'knight_select_view' username=username %}";
+        }
+    };
+    </script>
 
 </head>
 <body>

--- a/abaloneDjango/templates/abaloneDjango/knight_select.html
+++ b/abaloneDjango/templates/abaloneDjango/knight_select.html
@@ -61,12 +61,7 @@
         var message = data['message'];
 
         if (message == 'assin') {
-            // 0.5초 후 작동해야할 코드(원정시작 대기)
-            setTimeout(function(){
-               document.location.href = "{% url 'mycard_view' username=username %}";
-            }, 500);
-        } else if (message == 'init') {
-            document.location.href = "{% url 'knight_select_view' username=username %}";
+            document.location.href = "{% url 'mycard_view' username=username %}";
         }
     };
     </script>

--- a/abaloneDjango/templates/abaloneDjango/mycard.html
+++ b/abaloneDjango/templates/abaloneDjango/mycard.html
@@ -14,11 +14,24 @@
     </style>
 
     <script type="text/javascript">
-        //var timer = setInterval("timer_procedure();",5000);
+    // 클라이언트와 서버의 웹소켓 통신을 가능하도록 연결시켜주는 부분이다.
+    // router.py에서의 url과 일치하도록 해 주어야한다.
+    var web_socket = new WebSocket('ws://' + window.location.host + '/abalone/<str:username>/');
 
-        function timer_procedure(){
-            document.location.href = "{% url 'mycard_view' username=username %}";
+    // onmessage는 counsumers에서 보내는 메세지를 받는 부분이다.
+    web_socket.onmessage = function(e) {
+        var data = JSON.parse(e.data);
+        var message = data['message'];
+
+        if (message == 'assin') {
+            // 0.5초 후 작동해야할 코드(원정시작 대기)
+            setTimeout(function(){
+               document.location.href = "{% url 'mycard_view' username=username %}";
+            }, 500);
+        } else if (message == 'init') {
+            document.location.href = "{% url 'knight_select_view' username=username %}";
         }
+    };
     </script>
 
 

--- a/abaloneDjango/templates/abaloneDjango/mycard.html
+++ b/abaloneDjango/templates/abaloneDjango/mycard.html
@@ -24,10 +24,13 @@
         var message = data['message'];
 
         if (message == 'assin') {
-            // 0.5초 후 작동해야할 코드(원정시작 대기)
-            setTimeout(function(){
-               document.location.href = "{% url 'mycard_view' username=username %}";
-            }, 500);
+            document.location.href = "{% url 'mycard_view' username=username %}";
+        } else if (message == 'game_succ') {
+            document.location.href = "{% url 'knight_select_view' username=username %}";
+        } else if (message == 'game_fail') {
+            document.location.href = "{% url 'knight_select_view' username=username %}";
+        } else if (message == 'game_complete') {
+            document.location.href = "{% url 'knight_select_view' username=username %}";
         } else if (message == 'init') {
             document.location.href = "{% url 'knight_select_view' username=username %}";
         }

--- a/abaloneDjango/templates/abaloneDjango/start.html
+++ b/abaloneDjango/templates/abaloneDjango/start.html
@@ -21,7 +21,6 @@
 
     </script>
 
-
 </head>
 <body>
  * 참가완료 : {{ joinusercnt }} 명 , 준비완료 : {{ readyusercnt }}  명
@@ -72,8 +71,27 @@
 {% endfor %}
 </table>
  </BR>
-<input onclick="location.href={% url 'assin_view' %};return false;" value="원정시작" type="button" width="100%"/>
+<input id="start" onclick="location.href={% url 'assin_view' %};return false;" value="원정시작" type="button" width="100%"/>
 <input onclick="location.href={% url 'init_view' %};return false;" value="초기화" type="button" width="100%"/>
 <input onclick="location.href={% url 'start_view' %};return false;" value="새로고침" type="button" width="100%"/>
 </body>
+<script type="text/javascript">
+    // 클라이언트와 서버의 웹소켓 통신을 가능하도록 연결시켜주는 부분이다.
+    // router.py에서의 url과 일치하도록 해 주어야한다.
+    var web_socket = new WebSocket('ws://' + window.location.host + '/abalone/<str:username>/');
+
+    // onmessage는 counsumers에서 보내는 메세지를 받는 부분이다.
+    web_socket.onmessage = function(e) {
+        var data = JSON.parse(e.data);
+        var message = data['message'];
+
+        document.location.href = "{% url 'assin_view' %}";
+    };
+
+    document.querySelector('#start').onclick = function(e) {
+        web_socket.send(JSON.stringify({
+            'message': 'start'
+        }));
+    };
+</script>
 </html>

--- a/abaloneDjango/templates/abaloneDjango/start.html
+++ b/abaloneDjango/templates/abaloneDjango/start.html
@@ -8,6 +8,9 @@
         html{
             font-size : 15px;
         }
+        tr{
+            text-align:center
+        }
         td{
             border-color: #9d9d00;
             border-size: 1px;
@@ -18,7 +21,14 @@
     </style>
 
     <script type="text/javascript">
-
+    // 클라이언트와 서버의 웹소켓 통신을 가능하도록 연결시켜주는 부분이다.
+    // router.py에서의 url과 일치하도록 해 주어야한다.
+    var web_socket = new WebSocket('ws://' + window.location.host + '/abalone/<str:username>/');
+    // onmessage는 counsumers에서 보내는 메세지를 받는 부분이다.
+    web_socket.onmessage = function(e) {
+        var data = JSON.parse(e.data);
+        var message = data['message'];
+    };
     </script>
 
 </head>
@@ -26,7 +36,7 @@
  * 참가완료 : {{ joinusercnt }} 명 , 준비완료 : {{ readyusercnt }}  명
 <table>
     <tr>
-        <td width="150">참가자명</td>
+        <td width="150" style="text-align:left">참가자명</td>
         <td width="100">참가여부</td>
         <td width="100">준비완료</td>
         <td width="50">참가</td>
@@ -36,13 +46,13 @@
     </tr>
 {% for user in userlist %}
     <tr>
-        <td>{{ user.username }} [ <font color="white">{{ user.assinKnightId }}</font></td>
+        <td style="text-align:left">{{ user.username }}<font color="white">{{ user.assinKnightId }}</font></td>
         <td>{{ user.joinYn }}</td>
         <td>{{ user.readyYn }}</td>
-        <td><a href="{% url 'join_view' username=user.username %}">참가</a></td>
-        <td><a href="{% url 'delete_view' username=user.username %}">삭제</a></td>
-        <td><a href="{% url 'hosu_view' username=user.username %}">호수</a></td>
-        <td><a href="{% url 'knight_select_view' username=user.username %}">로긴</a></td>
+        <td><a href="{% url 'join_view' username=user.username %}"><input value="참가" type="button" width="100%"/></a></td>
+        <td><a href="{% url 'delete_view' username=user.username %}"><input value="삭제" type="button" width="100%"/></a></td>
+        <td><a href="{% url 'hosu_view' username=user.username %}"><input value="호수" type="button" width="100%"/></a></td>
+        <td><a href="{% url 'knight_select_view' username=user.username %}"><input value="로긴" type="button" width="100%"/></a></td>
     </tr>
 {% endfor %}
 </table>
@@ -63,29 +73,52 @@
         <td>{{ game.gameId }} </td>
         <td>{{ game.joinUserCnt }}</td>
         <td>{{ game.expeditionSeq }}</td>
-        <td><a href="{% url 'expeditionSeq_ini_view' gameid=game.gameId %}">차수취소</a></td>
-        <td><a href="{% url 'game_complete_view' gameid=game.gameId %}">완료</a></td>
-        <td><a href="{% url 'game_succ_view' gameid=game.gameId %}">선승</a></td>
-        <td><a href="{% url 'game_fail_view' gameid=game.gameId %}">악승</a></td>
+        <td><input id="expeditionSeq_ini" value="차수취소" type="button" width="100%"/></td>
+        <td><input id="game_complete" value="완료" type="button" width="100%"/></td>
+        <td><input id="game_succ" value="선승" type="button" width="100%"/></td>
+        <td><input id="game_fail" value="악승" type="button" width="100%"/></td>
     </tr>
+    <script type="text/javascript">
+    // 차수취소 버튼 클릭 시, 원정상황 페이지 최근 차수 취소
+    document.querySelector('#expeditionSeq_ini').onclick = function(e) {
+        document.location.href = "{% url 'expeditionSeq_ini_view' gameid=game.gameId %}";
+
+        web_socket.send(JSON.stringify({
+            'message': 'expeditionSeq_ini'
+        }));
+    };
+    // 완료 버튼 클릭 시, 참가자 카드선택 페이지로 변경
+    document.querySelector('#game_complete').onclick = function(e) {
+        document.location.href = "{% url 'game_complete_view' gameid=game.gameId %}";
+
+        web_socket.send(JSON.stringify({
+            'message': 'game_complete'
+        }));
+    };
+    // 선승 버튼 클릭 시, 참가자 카드선택 페이지로 변경
+    document.querySelector('#game_succ').onclick = function(e) {
+        document.location.href = "{% url 'game_succ_view' gameid=game.gameId %}";
+
+        web_socket.send(JSON.stringify({
+            'message': 'game_succ'
+        }));
+    };
+    // 악승 버튼 클릭 시, 참가자 카드선택 페이지로 변경
+    document.querySelector('#game_fail').onclick = function(e) {
+        document.location.href = "{% url 'game_fail_view' gameid=game.gameId %}";
+
+        web_socket.send(JSON.stringify({
+            'message': 'game_fail'
+        }));
+    };
+    </script>
 {% endfor %}
 </table>
  </BR>
 <input id="assin" value="원정시작" type="button" width="100%"/>
 <input id="init" value="초기화" type="button" width="100%"/>
 <input onclick="location.href={% url 'start_view' %};return false;" value="새로고침" type="button" width="100%"/>
-</body>
 <script type="text/javascript">
-    // 클라이언트와 서버의 웹소켓 통신을 가능하도록 연결시켜주는 부분이다.
-    // router.py에서의 url과 일치하도록 해 주어야한다.
-    var web_socket = new WebSocket('ws://' + window.location.host + '/abalone/<str:username>/');
-
-    // onmessage는 counsumers에서 보내는 메세지를 받는 부분이다.
-    web_socket.onmessage = function(e) {
-        var data = JSON.parse(e.data);
-        var message = data['message'];
-    };
-
     // 원정시작 버튼 클릭 시, 원정 시작 후, 참가자 내카드 페이지로 변경
     document.querySelector('#assin').onclick = function(e) {
         document.location.href = "{% url 'assin_view' %}";
@@ -104,4 +137,5 @@
         }));
     };
 </script>
+</body>
 </html>

--- a/abaloneDjango/templates/abaloneDjango/start.html
+++ b/abaloneDjango/templates/abaloneDjango/start.html
@@ -71,8 +71,8 @@
 {% endfor %}
 </table>
  </BR>
-<input id="start" onclick="location.href={% url 'assin_view' %};return false;" value="원정시작" type="button" width="100%"/>
-<input onclick="location.href={% url 'init_view' %};return false;" value="초기화" type="button" width="100%"/>
+<input id="assin" value="원정시작" type="button" width="100%"/>
+<input id="init" value="초기화" type="button" width="100%"/>
 <input onclick="location.href={% url 'start_view' %};return false;" value="새로고침" type="button" width="100%"/>
 </body>
 <script type="text/javascript">
@@ -84,13 +84,23 @@
     web_socket.onmessage = function(e) {
         var data = JSON.parse(e.data);
         var message = data['message'];
-
-        document.location.href = "{% url 'assin_view' %}";
     };
 
-    document.querySelector('#start').onclick = function(e) {
+    // 원정시작 버튼 클릭 시, 원정 시작 후, 참가자 내카드 페이지로 변경
+    document.querySelector('#assin').onclick = function(e) {
+        document.location.href = "{% url 'assin_view' %}";
+
         web_socket.send(JSON.stringify({
-            'message': 'start'
+            'message': 'assin'
+        }));
+    };
+
+    // 초기화 버튼 클릭 시, 초기화 진행 후, 참가자 카드선택 페이지로 변경
+    document.querySelector('#init').onclick = function(e) {
+        document.location.href = "{% url 'init_view' %}";
+
+        web_socket.send(JSON.stringify({
+            'message': 'init'
         }));
     };
 </script>

--- a/abaloneDjango/templates/abaloneDjango/wait.html
+++ b/abaloneDjango/templates/abaloneDjango/wait.html
@@ -23,11 +23,13 @@
         var data = JSON.parse(e.data);
         var message = data['message'];
 
-        if (message == 'start') {
-            // 1초 후 작동해야할 코드
+        if (message == 'assin') {
+            // 0.5초 후 작동해야할 코드(원정시작 대기)
             setTimeout(function(){
                document.location.href = "{% url 'mycard_view' username=username %}";
-            }, 1000);
+            }, 500);
+        } else if (message == 'init') {
+            document.location.href = "{% url 'knight_select_view' username=username %}";
         }
     };
     </script>

--- a/abaloneDjango/templates/abaloneDjango/wait.html
+++ b/abaloneDjango/templates/abaloneDjango/wait.html
@@ -14,11 +14,22 @@
     </style>
 
     <script type="text/javascript">
-        var timer = setInterval("timer_procedure();",5000);
+    // 클라이언트와 서버의 웹소켓 통신을 가능하도록 연결시켜주는 부분이다.
+    // router.py에서의 url과 일치하도록 해 주어야한다.
+    var web_socket = new WebSocket('ws://' + window.location.host + '/abalone/<str:username>/');
 
-        function timer_procedure(){
-            document.location.href = "{% url 'mycard_view' username=username %}";
+    // onmessage는 counsumers에서 보내는 메세지를 받는 부분이다.
+    web_socket.onmessage = function(e) {
+        var data = JSON.parse(e.data);
+        var message = data['message'];
+
+        if (message == 'start') {
+            // 1초 후 작동해야할 코드
+            setTimeout(function(){
+               document.location.href = "{% url 'mycard_view' username=username %}";
+            }, 1000);
         }
+    };
     </script>
 
 

--- a/abaloneDjango/templates/abaloneDjango/wait.html
+++ b/abaloneDjango/templates/abaloneDjango/wait.html
@@ -24,11 +24,14 @@
         var message = data['message'];
 
         if (message == 'assin') {
-            // 0.5초 후 작동해야할 코드(원정시작 대기)
-            setTimeout(function(){
-               document.location.href = "{% url 'mycard_view' username=username %}";
-            }, 500);
-        } else if (message == 'init') {
+            document.location.href = "{% url 'mycard_view' username=username %}";
+        } else if (message == 'game_succ') {
+            document.location.href = "{% url 'knight_select_view' username=username %}";
+        } else if (message == 'game_fail') {
+            document.location.href = "{% url 'knight_select_view' username=username %}";
+        } else if (message == 'game_complete') {
+            document.location.href = "{% url 'knight_select_view' username=username %}";
+        }else if (message == 'init') {
             document.location.href = "{% url 'knight_select_view' username=username %}";
         }
     };


### PR DESCRIPTION
(channels, channels_redis 패키지 추가 및 redis 설치/구동 필요)

1. py
consumer : 웹소켓 메시지 처리
router : 웹소켓 처리 url 
routing : setting에서 설정한 라우팅 설정
settings : channels, asgi, channel_layers 설정 추가

2. html
honor : 원정시작, 초기화, 완료, 선승, 악승 시 페이지 이동 추가
kinight_election : 원정시작, 초기화, 차수취소, 완료, 선승, 악승 시 페이지 이동 추가
knight_expedition : 원정시작, 투표, 초기화, 차수취소, 완료, 선승, 악승 시 페이지 이동 추가
knight_login : 버튼 추가
knight_select : 원정시작 시 페이지 이동 추가
mycard : 원정시작, 초기화, 완료, 선승, 악승 시 페이지 이동 추가
start : 버튼별(원정시작, 초기화, 완료, 선승, 악승, 차수취소) 웹소켓 전송 추가
wait : 원정시작, 초기화, 완료, 선승, 악승 시, 페이지 이동(카드선택 및 원정상황) 추가